### PR TITLE
Fix approval function for USDT on ethereum

### DIFF
--- a/hooks/transactions/approval/useApproval.ts
+++ b/hooks/transactions/approval/useApproval.ts
@@ -3,6 +3,7 @@ import { useAccount, useNetwork } from 'wagmi';
 
 import useGaslessApproval from './useGaslessApproval';
 import useTokenApproval from './useTokenApproval';
+import { mainnet } from 'wagmi/chains';
 
 interface UseTokenApprovalProps {
 	token: Token;
@@ -15,18 +16,23 @@ const useApproval = ({ token, spender, amount }: UseTokenApprovalProps) => {
 	const { address } = useAccount();
 	const { chain, chains } = useNetwork();
 
+	const chainInUse = chain || chains[0];
+	const noBooleanReturn = chainInUse.id === mainnet.id && token.symbol === 'USDT';
+
 	const withGasCall = useTokenApproval({
 		address: token.address,
 		spender,
-		amount
+		amount,
+		noBooleanReturn
 	});
 
 	const { gaslessEnabled, isFetching, isLoading, isSuccess, data, approve } = useGaslessApproval({
 		amount,
-		chain: chain || chains[0],
+		chain: chainInUse,
 		spender,
 		tokenAddress: token.address,
-		userAddress: address!
+		userAddress: address!,
+		noBooleanReturn
 	});
 
 	if (isFetching) {

--- a/hooks/transactions/approval/useGaslessApproval.ts
+++ b/hooks/transactions/approval/useGaslessApproval.ts
@@ -12,6 +12,7 @@ interface ApproveTokenProps {
 	userAddress: `0x${string}`;
 	spender: `0x${string}`;
 	amount: bigint;
+	noBooleanReturn: boolean;
 }
 
 const noncesAbi = parseAbi([
@@ -25,7 +26,14 @@ interface Data {
 	hash?: `0x${string}`;
 }
 
-const useGaslessApproval = ({ chain, tokenAddress, userAddress, spender, amount }: ApproveTokenProps) => {
+const useGaslessApproval = ({
+	chain,
+	tokenAddress,
+	userAddress,
+	spender,
+	amount,
+	noBooleanReturn
+}: ApproveTokenProps) => {
 	const [data, updateData] = useState<Data>({});
 	const [isSuccess, setIsSuccess] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
@@ -61,7 +69,11 @@ const useGaslessApproval = ({ chain, tokenAddress, userAddress, spender, amount 
 	}
 
 	const approve = async () => {
-		const abi = ['function approve(address spender, uint256 amount) external returns (bool)'];
+		const abi = [
+			noBooleanReturn
+				? 'function approve(address spender, uint256 value) public'
+				: 'function approve(address spender, uint256 amount) external returns (bool)'
+		];
 		const contractInterface = new Interface(abi);
 		const functionSignature = contractInterface.encodeFunctionData('approve', [spender, amount]);
 		const { r, s, v } = await signGaslessTransaction({

--- a/hooks/transactions/approval/useTokenApproval.ts
+++ b/hooks/transactions/approval/useTokenApproval.ts
@@ -4,13 +4,19 @@ interface UseTokenApprovalParams {
 	address: `0x${string}`;
 	spender: `0x${string}`;
 	amount: bigint;
+	noBooleanReturn: boolean;
 }
 
-const useTokenApproval = ({ address, spender, amount }: UseTokenApprovalParams) => {
+const useTokenApproval = ({ address, spender, amount, noBooleanReturn }: UseTokenApprovalParams) => {
 	const maxAllowance = amount === BigInt(0) ? BigInt(0) : BigInt(2 ** 256) - BigInt(1);
+	const abi = [
+		noBooleanReturn
+			? 'function approve(address spender, uint256 value) public'
+			: 'function approve(address spender, uint256 amount) external returns (bool)'
+	];
 	const { config } = usePrepareContractWrite({
 		address,
-		abi: erc20ABI,
+		abi,
 		functionName: 'approve',
 		args: [spender, maxAllowance]
 	});


### PR DESCRIPTION
Fix the ABI usage. The default ERC20 expects a boolean return on approve.

the default ABI defines that approve returns bool
the frontend simulate the transaction using this ABI
the simulated transaction does not return bool = error