### PR TITLE
Implement trusted users feature for ad listings

### DIFF
--- a/components/BlockedUsers.tsx
+++ b/components/BlockedUsers.tsx
@@ -50,7 +50,7 @@ const BlockedUsers: React.FC<BlockedUsersProps> = ({
 							'X-User-Address': address
 						}
 					});
-					const { blocked_users } = response.data;
+					const { blocked_users, trusted_by_users } = response.data;
 					setSelectedBlockedUsers(blocked_users || []);
 				} catch (error) {
 					console.error('Error fetching user relationships:', error);

--- a/components/Listing/Details.tsx
+++ b/components/Listing/Details.tsx
@@ -38,14 +38,27 @@ const Details = ({ list, updateList }: ListStepProps) => {
 		return <div>Loading...</div>;
 	}
 
-	const { terms, depositTimeLimit, paymentTimeLimit, type, chainId, token, acceptOnlyVerified, escrowType } = list;
+	// console.log('list.accept_only_trusted:', list.accept_only_trusted);
+
+	const {
+		terms,
+		depositTimeLimit,
+		paymentTimeLimit,
+		type,
+		chainId,
+		token,
+		acceptOnlyVerified,
+		acceptOnlyTrusted,
+		escrowType
+	} = list;
 	const { address } = useAccount();
 	const router = useRouter();
 	const { user, fetchUserProfile } = useUserProfile({});
 	const [lastVersion, setLastVersion] = useState(0);
 
 	const [selectedTrustedUsers, setSelectedTrustedUsers] = useState<User[]>([]);
-	const [acceptOnlyTrusted, setAcceptOnlyTrusted] = useState(false);
+
+	const [acceptOnlyTrustedState, setAcceptOnlyTrustedState] = useState(acceptOnlyTrusted);
 
 	const [selectedBlockedUsers, setSelectedBlockedUsers] = useState<User[]>([]);
 	const [acceptOnlyBlocked, setAcceptOnlyBlocked] = useState(false);
@@ -56,10 +69,11 @@ const Details = ({ list, updateList }: ListStepProps) => {
 				{
 					list: {
 						...list,
-						bankIds: (list.banks || []).map((b) => b.id)
+						bankIds: (list.banks || []).map((b) => b.id),
+						accept_only_trusted: acceptOnlyTrusted
 					},
 					data,
-					address // Include address in the body
+					address
 				},
 				{ deep: true }
 			);
@@ -119,8 +133,8 @@ const Details = ({ list, updateList }: ListStepProps) => {
 	const onProceed = () => {
 		if (!needToDeployOrFund) {
 			const updatedList = {
-				...list
-				// Removed 'trustedUsers' and 'acceptOnlyTrusted' from updatedList
+				...list,
+				accept_only_trusted: acceptOnlyTrusted
 			};
 			const message = listToMessage(updatedList);
 			signMessage({ message });
@@ -164,6 +178,10 @@ const Details = ({ list, updateList }: ListStepProps) => {
 		: needToDeploy
 		? 'Create Escrow Account'
 		: 'Deposit in the Escrow Account';
+
+	useEffect(() => {
+		setAcceptOnlyTrustedState(acceptOnlyTrusted);
+	}, [acceptOnlyTrusted]);
 
 	return (
 		<StepLayout onProceed={onProceed} buttonText={buttonText}>
@@ -238,8 +256,8 @@ const Details = ({ list, updateList }: ListStepProps) => {
 				</div>
 
 				<TrustedUsers
-					acceptOnlyTrusted={acceptOnlyTrusted}
-					setAcceptOnlyTrusted={setAcceptOnlyTrusted}
+					acceptOnlyTrusted={acceptOnlyTrustedState}
+					setAcceptOnlyTrusted={setAcceptOnlyTrustedState}
 					selectedTrustedUsers={selectedTrustedUsers}
 					setSelectedTrustedUsers={setSelectedTrustedUsers}
 					context="trade"

--- a/components/Listing/Listing.types.ts
+++ b/components/Listing/Listing.types.ts
@@ -30,6 +30,7 @@ export interface UIList {
 	escrowType: List['escrow_type'];
 	banks: Bank[];
 	priceSource: PriceSource | undefined;
+	acceptOnlyTrusted: boolean;
 }
 
 export interface ListStepProps {

--- a/components/ListsTable.tsx
+++ b/components/ListsTable.tsx
@@ -1,3 +1,4 @@
+// components/ListsTable.tsx
 /* eslint-disable no-mixed-spaces-and-tabs */
 /* eslint-disable @typescript-eslint/indent */
 import { useDynamicContext } from '@dynamic-labs/sdk-react-core';
@@ -21,6 +22,7 @@ import Token from './Token/Token';
 import IdVerificationNeeded from './IdVerificationNeeded';
 import Network from './Network/Network';
 import HiddenBadge from './HiddenBadge';
+import TrustedBadge from './TrustedBadge';
 
 interface ListsTableProps {
 	lists: List[];
@@ -161,7 +163,8 @@ const ListsTable = ({ lists, fiatAmount, tokenAmount, hideLowAmounts }: ListsTab
 						payment_time_limit: paymentTimeLimit,
 						escrow_type: escrowType,
 						type,
-						accept_only_verified: acceptOnlyVerified
+						accept_only_verified: acceptOnlyVerified,
+						accept_only_trusted: acceptOnlyTrusted
 					} = list;
 					const banks = type === 'BuyList' ? list.banks : paymentMethods.map((pm) => pm.bank);
 					const { address: sellerAddress, name } = seller;
@@ -342,6 +345,7 @@ const ListsTable = ({ lists, fiatAmount, tokenAmount, hideLowAmounts }: ListsTab
 										</div>
 									</div>
 									{showVerification && acceptOnlyVerified && <IdVerificationNeeded />}
+									{acceptOnlyTrusted && <TrustedBadge text="Trusted Only" />}
 								</div>
 								{isHidden && <HiddenBadge />}
 							</td>

--- a/components/TrustedBadge.tsx
+++ b/components/TrustedBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface BadgeProps {
+	text: string;
+	className?: string;
+}
+
+const Badge: React.FC<BadgeProps> = ({ text, className = '' }) => {
+	return (
+		<div className="flex flex-row my-2">
+			<div
+				className={`flex flex-row text-[12px] border border-blue-200 bg-blue-50 text-blue-600 px-2 rounded-md ${className}`}
+			>
+				{text}
+			</div>
+		</div>
+	);
+};
+
+export default Badge;

--- a/components/TrustedUsers.tsx
+++ b/components/TrustedUsers.tsx
@@ -68,7 +68,7 @@ const TrustedUsers: React.FC<TrustedUsersProps> = ({
 			const loadUsers = async () => {
 				try {
 					const data = await fetchUserRelationships();
-					const { trusted_users } = data; // Adjusted to match backend response
+					const { trusted_users, trusted_by_users } = data; // Adjusted to match backend response
 					setSelectedTrustedUsers(trusted_users || []);
 				} catch (error) {
 					console.error('Error fetching user relationships:', error);

--- a/components/TrustedUsers.tsx
+++ b/components/TrustedUsers.tsx
@@ -248,6 +248,10 @@ const TrustedUsers: React.FC<TrustedUsersProps> = ({
 		setShowTrustedUsers(!showTrustedUsers);
 	};
 
+	useEffect(() => {
+		// Fetch and set trusted users if acceptOnlyTrusted is true
+	}, [acceptOnlyTrusted, address]);
+
 	return (
 		<div className="mb-4">
 			{context === 'trade' ? (

--- a/models/types.ts
+++ b/models/types.ts
@@ -76,6 +76,7 @@ export interface List {
 	escrow_type: 'manual' | 'instant';
 	contract: `0x${string}` | undefined;
 	price_source: PriceSource;
+	accept_only_trusted: boolean;
 }
 
 export interface AccountField {

--- a/pages/ads/[id]/edit.tsx
+++ b/pages/ads/[id]/edit.tsx
@@ -1,3 +1,5 @@
+// pages/ads/[id]/edit.tsx
+
 import { getAuthToken } from '@dynamic-labs/sdk-react-core';
 import { AdjustmentsVerticalIcon } from '@heroicons/react/24/solid';
 import { Loading, Steps } from 'components';
@@ -44,7 +46,8 @@ const EditTrade = ({ id }: { id: number }) => {
 					accept_only_verified: acceptOnlyVerified,
 					escrow_type: escrowType,
 					banks,
-					price_source: priceSource
+					price_source: priceSource,
+					accept_only_trusted: acceptOnlyTrusted
 				} = data;
 				setList(data);
 				const currency = {
@@ -70,7 +73,8 @@ const EditTrade = ({ id }: { id: number }) => {
 					acceptOnlyVerified,
 					escrowType,
 					banks,
-					priceSource
+					priceSource,
+					acceptOnlyTrusted
 				};
 				setUiList(ui);
 			});

--- a/pages/api/lists/ads.ts
+++ b/pages/api/lists/ads.ts
@@ -43,11 +43,27 @@ const fetchLists = async (address: string, token: string): Promise<List[]> => {
 		}
 
 		const blockedUsers = userRelationships.blocked_users.map((user) => user.id);
+		const trustedUsers = userRelationships.trusted_users.map((user) => user.id);
 
-		// Filter lists to exclude those owned by blocked users
+		// Filter lists to exclude those owned by blocked users and ensure trusted users can see the ad
 		const filteredLists = lists.filter((list: List) => {
 			const ownerId = list.seller?.id;
-			return ownerId && !blockedUsers.includes(ownerId);
+			const isTrustedOnly = list.accept_only_trusted;
+			const isOwnerTrusted = trustedUsers.includes(ownerId);
+
+			if (!ownerId) {
+				return false;
+			}
+
+			if (blockedUsers.includes(ownerId)) {
+				return false;
+			}
+
+			if (isTrustedOnly && !isOwnerTrusted) {
+				return false;
+			}
+
+			return true;
 		});
 
 		return filteredLists;

--- a/pages/api/user_relationships/index.ts
+++ b/pages/api/user_relationships/index.ts
@@ -4,17 +4,22 @@ import { minkeApi } from '../utils/utils';
 
 const getUserRelationshipsFromApi = async (
 	address: string
-): Promise<{ trusted_users: User[]; blocked_users: User[]; blocked_by_users: User[] }> => {
+): Promise<{ trusted_users: User[]; blocked_users: User[]; blocked_by_users: User[]; trusted_by_users: User[] }> => {
 	const { data } = await minkeApi.get('/user_relationships', {
 		headers: {
 			'X-User-Address': address
 		}
 	});
-	return data.data;
+	return {
+		trusted_users: data.data.trusted_users,
+		blocked_users: data.data.blocked_users,
+		blocked_by_users: data.data.blocked_by_users,
+		trusted_by_users: data.data.trusted_by_users // Ensure this field is returned by the API
+	};
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-	const { method, query } = req;
+	const { method } = req;
 	const address = req.headers['x-user-address'] as string;
 
 	if (!address) {

--- a/pages/buy/[id].tsx
+++ b/pages/buy/[id].tsx
@@ -46,7 +46,7 @@ const BuyPage = ({ id }: { id: number }) => {
 					})
 				]);
 
-				const { blocked_users, blocked_by_users } = blockedUsersResponse.data;
+				const { blocked_users, blocked_by_users, trusted_users } = blockedUsersResponse.data;
 				const listData = listResponse;
 
 				setOrder({
@@ -64,6 +64,9 @@ const BuyPage = ({ id }: { id: number }) => {
 				} else if (blocked_by_users.some((user: any) => user.id === seller.id)) {
 					setIsBlocked(true);
 					setBlockedMessage('The owner of this offer has blocked you. Please choose another offer.');
+				} else if (listData.accept_only_trusted && !trusted_users.some((user: any) => user.id === address)) {
+					setIsBlocked(true);
+					setBlockedMessage('This ad is not available');
 				}
 
 				setSelectedBlockedUsers(blocked_users || []); // Set blocked users

--- a/pages/trade.tsx
+++ b/pages/trade.tsx
@@ -88,14 +88,28 @@ const HomePage: React.FC = () => {
 
 			const blockedUsers = blockedUsersResponse.data.blocked_users || [];
 			const blockedByUsers = blockedUsersResponse.data.blocked_by_users || [];
+			const trustedUsers = blockedUsersResponse.data.trusted_users || [];
 
 			const blockedUserIds = new Set([
 				...blockedUsers.map((user: User) => user.id),
 				...blockedByUsers.map((user: User) => user.id)
 			]);
 
-			// Filter out ads from blocked users
-			const filteredAds = data.filter((list: List) => !blockedUserIds.has(list.seller?.id));
+			// Filter out ads from blocked users and ensure trusted users can see the ad
+			const filteredAds = data.filter((list: List) => {
+				const isTrustedOnly = list.accept_only_trusted;
+				const isOwnerTrusted = trustedUsers.some((user: User) => user.id === list.seller?.id);
+
+				if (blockedUserIds.has(list.seller?.id)) {
+					return false;
+				}
+
+				if (isTrustedOnly && !isOwnerTrusted) {
+					return false;
+				}
+
+				return true;
+			});
 
 			const toBuyers = filteredAds.filter((list: List) => list.type === 'SellList');
 			const toSellers = filteredAds.filter((list: List) => list.type === 'BuyList');


### PR DESCRIPTION
This PR adds functionality to limit ad visibility to trusted users when selected by the ad creator. Key changes include:

- Added `accept_only_trusted` field to the List model
- Updated the ListsTable component to display a "Trusted Only" badge for ads with this setting
- Modified the ads API endpoint to filter listings based on trusted user relationships
- Updated the buy page to check if the current user is trusted by the seller
- Added logic in the trade page to filter listings based on trusted user relationships
- Created a new TrustedBadge component to visually indicate trusted-only listings
- Updated the ad creation and editing process to include the trusted users option

These changes allow users to create ads visible only to users they trust, enhancing privacy and security for P2P transactions. The feature is integrated seamlessly into the existing UI, with clear indicators for trusted-only listings.