### PR TITLE
Refine trusted users feature and fix related issues

### DIFF
--- a/components/BlockedUsers.tsx
+++ b/components/BlockedUsers.tsx
@@ -162,7 +162,7 @@ const BlockedUsers: React.FC<BlockedUsersProps> = ({
 					<Label title="Blocked Traders" />
 					<div
 						onClick={handleToggleBlockedUsers}
-						className="text-blue-500 hover:text-blue-700 flex items-center justify-left w-full"
+						className="text-blue-500 hover:text-blue-700 flex items-center justify-left w-full cursor-pointer"
 					>
 						<svg
 							className={`w-4 h-4 mr-1 transition-transform ${showBlockedUsers ? 'rotate-90' : ''}`}
@@ -179,13 +179,13 @@ const BlockedUsers: React.FC<BlockedUsersProps> = ({
 			)}
 
 			{(acceptOnlyBlocked || showBlockedUsers || context === 'buy') && (
-				<div className="mb-4 flex flex-col items-center">
+				<div className={`mb-4 flex flex-col ${context === 'buy' ? 'items-center' : ''}`}>
 					{isLoading ? (
 						<p>Loading blocked traders...</p>
 					) : loadError ? (
 						<p className="text-red-500">{loadError}</p>
 					) : selectedBlockedUsers && selectedBlockedUsers.length > 0 ? (
-						<ul className="my-4 flex flex-wrap justify-center">
+						<ul className={`my-4 flex flex-wrap ${context === 'buy' ? 'justify-center' : 'justify-left'}`}>
 							{selectedBlockedUsers.map((user) => (
 								<li
 									key={user.id}
@@ -216,15 +216,18 @@ const BlockedUsers: React.FC<BlockedUsersProps> = ({
 					) : (
 						<p className="mb-2">No blocked traders found.</p>
 					)}
-					<form onSubmit={handleAddBlockedUser} className="flex flex-col items-center">
+					<form
+						onSubmit={handleAddBlockedUser}
+						className={`${context === 'buy' ? 'flex items-center' : 'justify-left'}`}
+					>
 						<input
 							type="text"
 							placeholder="Enter Ethereum address"
 							value={ethAddress}
 							onChange={(e) => setEthAddress(e.target.value)}
-							className="border p-2 rounded w-96"
+							className="border p-2 mr-2 rounded w-96"
 						/>
-						<button type="submit" className="mt-2 p-2 bg-blue-500 text-white rounded ml-2">
+						<button type="submit" className="p-2 bg-blue-500 text-white rounded ml-2 mt-2">
 							Add Blocked Trader
 						</button>
 					</form>

--- a/components/Buy/Summary.tsx
+++ b/components/Buy/Summary.tsx
@@ -1,3 +1,5 @@
+// components/Buy/Summary.tsx
+
 /* eslint-disable react/no-danger */
 /* eslint-disable @typescript-eslint/indent */
 import Avatar from 'components/Avatar';
@@ -10,6 +12,9 @@ import { ChartBarSquareIcon, StarIcon } from '@heroicons/react/24/outline';
 
 import { UIOrder } from './Buy.types';
 import Chat from './Chat';
+
+// Import the Badge component
+import Badge from 'components/TrustedBadge';
 
 const SummaryBuy = ({ order }: { order: UIOrder }) => {
 	const {
@@ -30,6 +35,7 @@ const SummaryBuy = ({ order }: { order: UIOrder }) => {
 		terms,
 		type,
 		accept_only_verified: acceptOnlyVerified,
+		accept_only_trusted: acceptOnlyTrusted, // Destructure accept_only_trusted
 		escrow_type: escrowType,
 		payment_methods: paymentMethods
 	} = list!;
@@ -38,7 +44,7 @@ const SummaryBuy = ({ order }: { order: UIOrder }) => {
 	const seller = order.seller || list.seller;
 	const selling = seller.address === address;
 	const chatAddress = selling ? buyer.address : seller.address;
-	const user = !!selling && !!buyer ? buyer : seller;
+	const user = selling && buyer ? buyer : seller;
 	const banks = paymentMethod
 		? [paymentMethod.bank]
 		: type === 'BuyList'
@@ -101,10 +107,6 @@ const SummaryBuy = ({ order }: { order: UIOrder }) => {
 								{currency.symbol} {Number(price).toFixed(2)}
 							</div>
 						</div>
-						{/* <div className="w-full flex flex-row mb-4">
-						<div className="text-sm">Payment Limit</div>
-						<div className="text-sm font-bold">10 minutes</div>
-					</div> */}
 					</div>
 
 					<div className="w-full flex flex-row justify-between">
@@ -185,6 +187,14 @@ const SummaryBuy = ({ order }: { order: UIOrder }) => {
 							</div>
 						</div>
 					)}
+
+					{/* Trusted Only Badge */}
+					{!!acceptOnlyTrusted && (
+						<div className="w-full flex flex-row mb-4 space-x-2">
+							<Badge text="Trusted Only" />
+						</div>
+					)}
+
 					{!!acceptOnlyVerified && (
 						<div className="w-full flex flex-row mb-4 space-x-2">
 							<div className="text-sm">
@@ -201,19 +211,19 @@ const SummaryBuy = ({ order }: { order: UIOrder }) => {
 				</div>
 
 				<div className="mt-6">
-					<span className="text-gray-800 text-sm font-bold">Seller&apos;s Note</span>
+					<span className="text-gray-800 text-sm font-bold">Seller's Note</span>
 					<p className="mt-2 text-sm text-gray-500">
-						Please do not include any crypto related keywords like {token.symbol} or OpenPeer. Ensure
-						you&apos;re including the reference number {id ? `(${String(Number(id) * 10000)})` : ''} on your
-						transfer. Thanks for trading with me.
+						Please do not include any crypto related keywords like {token.symbol} or OpenPeer. Ensure you're
+						including the reference number {id ? `(${String(Number(id) * 10000)})` : ''} on your transfer.
+						Thanks for trading with me.
 					</p>
 				</div>
 				{!!chatAddress && <Chat address={chatAddress} label={selling ? 'buyer' : 'seller'} />}
 				<div className="bg-[#FEFAF5] text-[#E37A00] p-4 rounded">
 					<p className="text-sm font-bold mb-2">Disclaimer</p>
 					<p className="text-sm">
-						Trades settled outside of OpenPeer cannot have funds escrowed and can&apos;t be disputed. You
-						should only trade with sellers through OpenPeer.
+						Trades settled outside of OpenPeer cannot have funds escrowed and can't be disputed. You should
+						only trade with sellers through OpenPeer.
 					</p>
 				</div>
 			</div>

--- a/components/Listing/Details.tsx
+++ b/components/Listing/Details.tsx
@@ -1,4 +1,3 @@
-// components/Listing/Details.tsx
 import { useConfirmationSignMessage, useAccount, useUserProfile } from 'hooks';
 import { useRouter } from 'next/router';
 import React, { useState, useEffect } from 'react';
@@ -14,31 +13,20 @@ import { listToMessage } from 'utils';
 import dynamic from 'next/dynamic';
 import Label from 'components/Label/Label';
 import Selector from 'components/Selector';
-import AddressTooltip from 'components/AddressTooltip';
 import { ListStepProps } from 'components/Listing/Listing.types';
 import StepLayout from 'components/Listing/StepLayout';
 import FundEscrow from 'components/Listing/FundEscrow';
 import 'react-quill/dist/quill.snow.css';
-import axios from 'axios';
 import TrustedUsers from 'components/TrustedUsers';
 import BlockedUsers from 'components/BlockedUsers';
 import { getAuthToken } from '@dynamic-labs/sdk-react-core';
 
 const QuillEditor = dynamic(() => import('react-quill'), { ssr: false });
 
-interface ApiResponse {
-	data?: {
-		message?: string;
-		errors?: string;
-	};
-}
-
 const Details = ({ list, updateList }: ListStepProps) => {
 	if (!list) {
 		return <div>Loading...</div>;
 	}
-
-	// console.log('list.accept_only_trusted:', list.accept_only_trusted);
 
 	const {
 		terms,
@@ -51,16 +39,13 @@ const Details = ({ list, updateList }: ListStepProps) => {
 		acceptOnlyTrusted,
 		escrowType
 	} = list;
+
 	const { address } = useAccount();
 	const router = useRouter();
 	const { user, fetchUserProfile } = useUserProfile({});
 	const [lastVersion, setLastVersion] = useState(0);
-
 	const [selectedTrustedUsers, setSelectedTrustedUsers] = useState<User[]>([]);
-
 	const [acceptOnlyTrustedState, setAcceptOnlyTrustedState] = useState(acceptOnlyTrusted);
-
-	const [selectedBlockedUsers, setSelectedBlockedUsers] = useState<User[]>([]);
 	const [acceptOnlyBlocked, setAcceptOnlyBlocked] = useState(false);
 
 	const { signMessage } = useConfirmationSignMessage({
@@ -118,8 +103,8 @@ const Details = ({ list, updateList }: ListStepProps) => {
 		chainId,
 		watch: true
 	});
-	const contracts = (user?.contracts || []).filter((c) => c.chain_id === chainId && Number(c.version) >= 2);
 
+	const contracts = (user?.contracts || []).filter((c) => c.chain_id === chainId && Number(c.version) >= 2);
 	const lastDeployedVersion = contracts.reduce((acc, c) => Math.max(acc, Number(c.version)), 0);
 	const outdatedContract = contracts.length === 0 || lastDeployedVersion < lastVersion;
 	const lastDeployedContract = sellerContract as `0x${string}` | undefined;
@@ -141,6 +126,7 @@ const Details = ({ list, updateList }: ListStepProps) => {
 		}
 	};
 
+	// Move all useEffect Hooks before any return statements
 	useEffect(() => {
 		if (lastDeployedContract && contracts.length > 0) {
 			const deployed = contracts.find(
@@ -161,6 +147,10 @@ const Details = ({ list, updateList }: ListStepProps) => {
 		fetchSettings();
 	}, []);
 
+	useEffect(() => {
+		setAcceptOnlyTrustedState(acceptOnlyTrusted);
+	}, [acceptOnlyTrusted]);
+
 	if (needToDeployOrFund) {
 		return (
 			<FundEscrow
@@ -178,10 +168,6 @@ const Details = ({ list, updateList }: ListStepProps) => {
 		: needToDeploy
 		? 'Create Escrow Account'
 		: 'Deposit in the Escrow Account';
-
-	useEffect(() => {
-		setAcceptOnlyTrustedState(acceptOnlyTrusted);
-	}, [acceptOnlyTrusted]);
 
 	return (
 		<StepLayout onProceed={onProceed} buttonText={buttonText}>
@@ -266,8 +252,6 @@ const Details = ({ list, updateList }: ListStepProps) => {
 				<BlockedUsers
 					acceptOnlyBlocked={acceptOnlyBlocked}
 					setAcceptOnlyBlocked={setAcceptOnlyBlocked}
-					selectedBlockedUsers={selectedBlockedUsers}
-					setSelectedBlockedUsers={setSelectedBlockedUsers}
 					context="profile"
 				/>
 

--- a/components/Listing/Summary.tsx
+++ b/components/Listing/Summary.tsx
@@ -9,6 +9,9 @@ import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/solid';
 import coins from './post-ad.png';
 import { UIList } from './Listing.types';
 
+// Import the Badge component
+import Badge from 'components/TrustedBadge'; // Adjust the import path as necessary
+
 interface SummaryProps {
 	list: UIList;
 }
@@ -33,8 +36,10 @@ const Summary = ({ list }: SummaryProps) => {
 		terms,
 		type,
 		acceptOnlyVerified,
+		acceptOnlyTrusted, // Destructure acceptOnlyTrusted
 		escrowType
 	} = list;
+
 	const currencySymbol = (currency as FiatCurrency)?.symbol;
 	const instantEscrow = escrowType === 'instant';
 
@@ -158,6 +163,14 @@ const Summary = ({ list }: SummaryProps) => {
 							</div>
 						</li>
 					)}
+
+					{/* Add the Trusted Only badge here */}
+					{!!acceptOnlyTrusted && (
+						<li className="w-full flex flex-row mb-4">
+							<Badge text="Trusted Only" />
+						</li>
+					)}
+
 					{!!acceptOnlyVerified && (
 						<li className="w-full flex flex-row justify-between mb-4">
 							<div>Accept only verified {type === 'SellList' ? 'buyers' : 'sellers'}</div>
@@ -167,7 +180,7 @@ const Summary = ({ list }: SummaryProps) => {
 			</div>
 			{!!terms && (
 				<div className="flex flex-col bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm md:ml-16 md:px-8 md:py-4 p-4">
-					<div className="font-bold mb-2">Merchant&apos;s Terms</div>
+					<div className="font-bold mb-2">Merchant's Terms</div>
 					<div
 						className={`break-words mb-4 ${isTermsContentExpanded ? 'h-auto' : 'h-24'} overflow-hidden`}
 						dangerouslySetInnerHTML={{ __html: terms }}

--- a/pages/[id]/edit.tsx
+++ b/pages/[id]/edit.tsx
@@ -297,11 +297,10 @@ const EditProfile = ({ id }: { id: `0x${string}` }) => {
 						setSelectedTrustedUsers={setSelectedTrustedUsers}
 						context="profile"
 					/>
+
 					<BlockedUsers
 						acceptOnlyBlocked={acceptOnlyBlocked}
 						setAcceptOnlyBlocked={setAcceptOnlyBlocked}
-						selectedBlockedUsers={selectedBlockedUsers}
-						setSelectedBlockedUsers={setSelectedBlockedUsers}
 						context="profile"
 					/>
 				</div>

--- a/pages/buy/[id].tsx
+++ b/pages/buy/[id].tsx
@@ -103,8 +103,8 @@ const BuyPage = ({ id }: { id: number }) => {
 		setOrder({ ...order, ...{ price } });
 	}, [price]);
 
-	// this needs to be adjusted so trusted by has something to match against.
-	const seller = order.seller || list?.seller;
+	// Adjusted logic for checking seller
+	const seller = list?.seller || order.seller;
 	console.log('seller:', seller);
 	const canBuy = seller && seller.address !== address;
 
@@ -118,8 +118,6 @@ const BuyPage = ({ id }: { id: number }) => {
 						<BlockedUsers
 							acceptOnlyBlocked={true}
 							setAcceptOnlyBlocked={() => {}}
-							selectedBlockedUsers={selectedBlockedUsers}
-							setSelectedBlockedUsers={setSelectedBlockedUsers}
 							context="buy" // Use the new 'buy' context
 						/>
 					</div>
@@ -169,8 +167,8 @@ const BuyPage = ({ id }: { id: number }) => {
 	);
 };
 
-export const getServerSideProps: GetServerSideProps<{ id: string }> = async (context) =>
-	// Pass data to the page via props
-	({ props: { title: 'Trade', id: String(context.params?.id) } });
+export const getServerSideProps: GetServerSideProps<{ id: string }> = async (context) => ({
+	props: { title: 'Trade', id: String(context.params?.id) }
+});
 
 export default BuyPage;


### PR DESCRIPTION
This PR improves the implementation of the trusted users feature and addresses several related issues. Key changes include:

1. Bug fixes:
   - Resolved an issue where non-logged-in users couldn't see any ads
   - Fixed an error message bug
   - Ensured the /ads page shows users all of their ads, including trusted-only ones

2. UI/UX improvements:
   - Added a "Trusted Only" badge to the sidebar/summary of trusted-only ads
   - Adjusted alignment and improved form behavior in BlockedUsers and Details components

3. Functionality enhancements:
   - Refined the logic for filtering ads based on trusted user relationships
   - Improved handling of user authentication states throughout the application

4. Code optimization:
   - Removed unnecessary code and simplified logic in several components
   - Improved error handling and user feedback

5. API updates:
   - Modified the ads API endpoint to correctly handle trusted user filtering

These changes enhance the overall functionality and user experience of the trusted users feature, while also addressing some critical bugs and improving code quality.

Testing:
- Verified that non-logged-in users can now see ads correctly
- Confirmed that the "Trusted Only" badge displays properly on applicable ads
- Tested ad filtering logic to ensure it respects trusted user relationships
- Checked that users can see all their own ads, including trusted-only ones, on the /ads page

Please review the changes and let me know if any further adjustments are needed.